### PR TITLE
Add persistence.xml into .gitignore #123

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /target/
 /src/main/webapp/WEB-INF/glassfish-resources.xml
 glassfish-resources.xml
+*/META-INF/*
+src/main/resources/META-INF/persistence.xml


### PR DESCRIPTION
This change is done to omit the changes that happen in each pull from the origin. persistent.xml will not be fetched when new developers clone the project and they have to create their own one in their local dev env. This was not able to test in local dev env, although I added this XML into .gitignore it could be seen in the local repo. But thought to push it into remote to check whether it is working in the remote.