### PR TITLE
Can not see province and district in the client registration for a in…

### DIFF
--- a/src/main/webapp/reports/client_registrations/for_system_by_ins.xhtml
+++ b/src/main/webapp/reports/client_registrations/for_system_by_ins.xhtml
@@ -79,6 +79,20 @@
                                       >
                                 <p:outputLabel value="#{c.institution.rdhsArea.name}" ></p:outputLabel>
                             </p:column>
+                            <p:column headerText="Province" 
+                                      filterBy="#{c.institution.province.name}" 
+                                      filterMatchMode="contains" 
+                                      sortBy="#{c.institution.province.name}"
+                                      >
+                                <p:outputLabel value="#{c.institution.province.name}" ></p:outputLabel>
+                            </p:column>
+                            <p:column headerText="District" 
+                                      filterBy="#{c.institution.district.name}" 
+                                      filterMatchMode="contains" 
+                                      sortBy="#{c.institution.district.name}"
+                                      >
+                                <p:outputLabel value="#{c.institution.district.name}" ></p:outputLabel>
+                            </p:column>
                             <p:column headerText="Institution" 
                                       filterBy="#{c.institution.name}" 
                                       filterMatchMode="contains" 


### PR DESCRIPTION
Can not see province and district in the client registration for an institution report

PSSP project needs the district and the province of each institution to aggregate the client registration for each district and province. Institution vice client registration table does not contain the province and district for each institution. 

solution
Adding new two columns to show District and the Province in the report.